### PR TITLE
DEVX-11042: Reduce Silent Auth latency with connectivity pre-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# Vonage iOS Client Library – AI Agent Guide
+
+## Overview
+
+This library enables iOS apps to interact with Vonage Network APIs that require redirection and cellular connection forcing, focusing on cellular network requests for number verification and silent authentication. It is compatible with iOS 13+ and supports both Swift Package Manager and CocoaPods for installation.
+
+---
+
+## Installation
+
+### Swift Package Manager
+```swift
+.package(url: "https://github.com/Vonage/vonage-ios-client-library.git")
+```
+
+### CocoaPods
+```ruby
+pod 'VonageClientLibrary'
+```
+
+---
+
+## Main Components
+
+### 1. VGCellularRequestClient
+- **Purpose:** Main entry point for making cellular GET requests.
+- **Usage:**
+  ```swift
+  import VonageClientLibrary
+  let client = VGCellularRequestClient()
+  let params = VGCellularRequestParameters(
+      url: "http://www.vonage.com",
+      headers: ["x-my-header": "My Value"],
+      queryParameters: ["query-param": "value"],
+      maxRedirectCount: 10
+  )
+  let response = try await client.startCellularGetRequest(params: params, debug: true)
+  ```
+- **Parameters:**
+  - `url`: Target URL
+  - `headers`: HTTP headers
+  - `queryParameters`: URL query params
+  - `maxRedirectCount`: Optional, default 10
+  - `timeout`: Optional, default 5.0 seconds
+  - `debug`: Optional, default false
+
+### 2. VGCellularRequestParameters
+- **Purpose:** Encapsulates request configuration.
+- **Fields:** url, headers, queryParameters, maxRedirectCount, timeout
+
+### 3. CellularClient (protocol) & VGCellularClient (implementation)
+- **Purpose:** Handles the actual network request logic, including cellular connectivity enforcement and redirect handling.
+
+### 4. CellularConnectionManager
+- **Purpose:** Manages low-level network connections, enforces cellular-only paths, handles redirects, errors, and debug tracing.
+
+### 5. TraceCollector & DebugInfo
+- **Purpose:** Collects trace/debug info for requests, including device info and URL traces.
+
+---
+
+## Error Handling
+- Errors are returned as dictionaries with `error`, `error_description`, and optional `debug` info.
+- Common error codes:
+  - `sdk_no_data_connectivity`
+  - `sdk_connection_error`
+  - `sdk_redirect_error`
+  - `sdk_error`
+
+---
+
+## Migrating from Previous SDKs
+- Replace imports of `VonageClientSDKNumberVerification` or `VonageClientSDKSilentAuth` with `VonageClientLibrary`.
+- Replace client instantiations with `VGCellularRequestClient()`.
+- Use `VGCellularRequestParameters` for request configuration.
+
+---
+
+## Testing
+- Tests are located in `Tests/VonageClientLibraryTests/`.
+- Includes tests for URL generation and error handling using a `MockCellularClient`.
+
+---
+
+## Project Structure
+- `Sources/VonageClientLibrary/` – Main library code
+- `Sources/VonageClientLibrary/CellularClient/` – Core networking logic
+- `Tests/VonageClientLibraryTests/` – Unit tests
+
+---
+
+## Example Response
+**Success:**
+```json
+{
+  "http_status": "200",
+  "response_body": { ... },
+  "debug": {
+    "device_info": "iOS/17.0",
+    "url_trace": "..."
+  }
+}
+```
+**Error:**
+```json
+{
+  "error": "sdk_no_data_connectivity",
+  "error_description": "No cellular data connectivity available.",
+  "debug": { ... }
+}
+```
+
+---
+
+## Additional Notes for AI Agents
+- All network requests are forced over cellular (not WiFi) when possible.
+- Debugging and trace collection can be enabled via the `debug` parameter.
+- The library is written in Swift and uses Apple's Network framework for low-level connectivity.
+- The codebase is modular, with clear separation between request configuration, network logic, and trace/debug utilities.
+- Error handling is robust and returns structured dictionaries for easy parsing.
+- Tests use a mock client for isolation and coverage of edge cases.
+- For migration, update imports and client instantiations as described above.
+- See the README and inline code documentation for further details on usage and extension.
+- This library uses Semantic Versioning. Make sure all changes are regulated to MINOR or PATCH changes - if a change would introduce a MAJOR version bump, discuss with the user first.
+
+---
+
+## References
+- [Vonage Number Verification](https://developer.vonage.com/en/number-verification/overview)
+- [Vonage Verify Silent Authentication](https://developer.vonage.com/en/verify/guides/silent-authentication)
+- [GitHub Repository](https://github.com/Vonage/vonage-ios-client-library)
+
+---
+
+*This file is intended for use by AI agents (e.g., GitHub Copilot, future LLMs) to understand, maintain, and extend the Vonage iOS Client Library codebase efficiently.*

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ let response = try await client.startCellularGetRequest(params: params, debug: t
 
 if let debug = response["debug"] as? [String: Any],
    let operatorHeaders = debug["operator_headers"] as? [String: [String]] {
-    print(operatorHeaders) // e.g. ["X-Orange-Trace-Id": ["abc123"]]
+    print(operatorHeaders) // e.g. ["x-orange-trace-id": ["abc123"]]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,39 @@ let response = try await client.startCellularGetRequest(params: params, debug: t
 * `maxRedirectCount` in `VGCellularRequestParameters` is an optional and defaults to 10.
 * `debug` parameter for `startCellularRequest` is optional and defaults to false.
 
+### Custom Logging
+
+Assign a logger to receive SDK log messages through your preferred logging framework. Implement the `VGLogger` protocol and set it on the client:
+
+```swift
+import VonageClientLibrary
+
+class MyLogger: NSObject, VGLogger {
+    func log(_ message: String, level: VGLogLevel) {
+        // Forward to your preferred logging framework, e.g. OSLog, CocoaLumberjack, etc.
+        print("[\(level)] \(message)")
+    }
+}
+
+let client = VGCellularRequestClient()
+client.logger = MyLogger()
+```
+
+The logger receives all SDK messages regardless of whether `debug` is enabled. `VGLogLevel` values are `.debug`, `.info`, `.warning`, and `.error`.
+
+### Operator Headers
+
+When `debug: true`, any `X-*` headers returned in redirect responses (such as operator trace IDs like `X-Orange-Trace-Id`) are captured and returned in the response under `debug.operator_headers`. Multiple values for the same header (across redirect hops) are preserved as an array.
+
+```swift
+let response = try await client.startCellularGetRequest(params: params, debug: true)
+
+if let debug = response["debug"] as? [String: Any],
+   let operatorHeaders = debug["operator_headers"] as? [String: [String]] {
+    print(operatorHeaders) // e.g. ["X-Orange-Trace-Id": ["abc123"]]
+}
+```
+
 #### Responses
 
 * Success - When the data connectivity has been achieved, and a response has been received from the url endpoint:
@@ -58,7 +91,10 @@ let response = try await client.startCellularGetRequest(params: params, debug: t
     },
     "debug" : {
         "device_info": string, 
-        "url_trace" : string
+        "url_trace" : string,
+        "operator_headers": { // X-* headers seen across all hops
+            "X-Orange-Trace-Id": [string]
+        }
     }
 }
 ```
@@ -71,7 +107,10 @@ let response = try await client.startCellularGetRequest(params: params, debug: t
     "error_description": string,
     "debug" : {
         "device_info": string, 
-        "url_trace" : string
+        "url_trace" : string,
+        "operator_headers": { // X-* headers seen across all hops
+            "X-Orange-Trace-Id": [string]
+        }
     }
 }
 ```

--- a/Sources/VonageClientLibrary/CellularClient/CellularClient.swift
+++ b/Sources/VonageClientLibrary/CellularClient/CellularClient.swift
@@ -36,6 +36,9 @@ class VGCellularClient: CellularClient {
     }
     
     func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?) async -> [String: Any] {
+        // Set the logger before the connectivity check so early trace logs reach the custom logger.
+        connectionManager.traceCollector.logger = logger
+
         // Perform the cellular connectivity check asynchronously, off the
         // cooperative thread pool, before entering withCheckedContinuation.
         let hasCellular = await connectionManager.checkCellularConnectivityAsync()

--- a/Sources/VonageClientLibrary/CellularClient/CellularClient.swift
+++ b/Sources/VonageClientLibrary/CellularClient/CellularClient.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreTelephony
 
 protocol CellularClient {
-    func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval) async -> [String: Any]
+    func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?) async -> [String: Any]
 }
 
 class VGCellularClient: CellularClient {
@@ -35,11 +35,12 @@ class VGCellularClient: CellularClient {
         }
     }
     
-    func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval) async -> [String: Any] {
+    func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?) async -> [String: Any] {
         // Perform the cellular connectivity check asynchronously, off the
         // cooperative thread pool, before entering withCheckedContinuation.
         let hasCellular = await connectionManager.checkCellularConnectivityAsync()
         if !hasCellular {
+            logger?.log("sdk_no_data_connectivity: Data connectivity not available", level: .error)
             var json = [String: Any]()
             json["error"] = "sdk_no_data_connectivity"
             json["error_description"] = "Data connectivity not available"
@@ -47,6 +48,7 @@ class VGCellularClient: CellularClient {
                 var debugJson = [String: Any]()
                 debugJson["device_info"] = DebugInfo().deviceString()
                 debugJson["url_trace"] = ""
+                debugJson["operator_headers"] = [String: [String]]()
                 json["debug"] = debugJson
             }
             return json
@@ -55,7 +57,7 @@ class VGCellularClient: CellularClient {
         return await withCheckedContinuation { continuation in
             var hasResumed = false
             let lock = NSLock()
-            connectionManager.get(url: url, headers: headers, maxRedirectCount: maxRedirectCount, debug: debug, timeout: timeout) { response in
+            connectionManager.get(url: url, headers: headers, maxRedirectCount: maxRedirectCount, debug: debug, timeout: timeout, logger: logger) { response in
                 lock.lock()
                 defer { lock.unlock() }
                 if !hasResumed {

--- a/Sources/VonageClientLibrary/CellularClient/CellularClientModels.swift
+++ b/Sources/VonageClientLibrary/CellularClient/CellularClientModels.swift
@@ -38,9 +38,7 @@ public class DebugInfo {
     }
     
     public func deviceString() -> String {
-        var device: String = ""
-        device = UIDevice.current.systemName + "/" + UIDevice.current.systemVersion
-        return device
+        return UIDevice.current.systemName + "/" + UIDevice.current.systemVersion
     }
 }
 
@@ -99,4 +97,3 @@ enum ConnectionResult {
     case dataErr(ConnectionResponse)
     case follow(RedirectResult)
 }
-

--- a/Sources/VonageClientLibrary/CellularClient/CellularConnectionManager.swift
+++ b/Sources/VonageClientLibrary/CellularClient/CellularConnectionManager.swift
@@ -21,14 +21,15 @@ class CellularConnectionManager {
     private var pathMonitor: NWPathMonitor?
     private var checkResponseHandler: ResultHandler!
     private var debugInfo = DebugInfo()
-    private let sdkVersion = "1.0.5"
+    private let sdkVersion = "1.1.0"
     
     lazy var traceCollector: TraceCollector = {
         TraceCollector()
     }()
     
-    func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, completion: @escaping ([String : Any]) -> Void) {
+    func get(url: URL, headers: [String: String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?, completion: @escaping ([String : Any]) -> Void) {
         self.connectionTimeout = timeout
+        traceCollector.logger = logger
         
         if (debug) {
             traceCollector.isDebugInfoCollectionEnabled = true
@@ -106,6 +107,7 @@ class CellularConnectionManager {
             var json_debug: [String : Any] = [:]
             json_debug["device_info"] = ti.debugInfo.deviceString()
             json_debug["url_trace"] = ti.trace
+            json_debug["operator_headers"] = self.traceCollector.operatorHeaders()
             json["debug"] = json_debug
             self.traceCollector.stopTrace()
         }
@@ -152,6 +154,7 @@ class CellularConnectionManager {
             var json_debug: [String : Any] = [:]
             json_debug["device_info"] = ti.debugInfo.deviceString()
             json_debug["url_trace"] = ti.trace
+            json_debug["operator_headers"] = self.traceCollector.operatorHeaders()
             json["debug"] = json_debug
             self.traceCollector.stopTrace()
         }
@@ -536,6 +539,7 @@ class CellularConnectionManager {
                 // Log all response headers if debug mode is enabled
                 if self.traceCollector.isDebugInfoCollectionEnabled {
                     self.logResponseHeaders(response: response)
+                    self.extractOperatorHeaders(response: response)
                 }
                 
                 let status = self.parseHttpStatusCode(response: response)
@@ -664,6 +668,24 @@ class CellularConnectionManager {
             }
         }
         self.traceCollector.addDebug(log: "========================")
+    }
+
+    /// Extracts `X-*` operator headers from a raw HTTP response and accumulates them
+    /// on the trace collector. Case-insensitive header name matching. Each unique name
+    /// collects all values seen across redirect hops.
+    func extractOperatorHeaders(response: String) {
+        guard let headerEndRange = response.range(of: "\r\n\r\n") else { return }
+        let headerSection = response[..<headerEndRange.lowerBound]
+        let lines = headerSection.components(separatedBy: "\r\n")
+        for line in lines {
+            guard let colonRange = line.range(of: ":") else { continue }
+            let name = String(line[..<colonRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let value = String(line[colonRange.upperBound...]).trimmingCharacters(in: .whitespaces)
+            if name.lowercased().hasPrefix("x-") {
+                traceCollector.addOperatorHeader(name: name, value: value)
+                traceCollector.logger?.log("Operator header: \(name): \(value)", level: .debug)
+            }
+        }
     }
     
 }

--- a/Sources/VonageClientLibrary/CellularClient/CellularConnectionManager.swift
+++ b/Sources/VonageClientLibrary/CellularClient/CellularConnectionManager.swift
@@ -682,7 +682,7 @@ class CellularConnectionManager {
             let name = String(line[..<colonRange.lowerBound]).trimmingCharacters(in: .whitespaces)
             let value = String(line[colonRange.upperBound...]).trimmingCharacters(in: .whitespaces)
             if name.lowercased().hasPrefix("x-") {
-                traceCollector.addOperatorHeader(name: name, value: value)
+                traceCollector.addOperatorHeader(name: name.lowercased(), value: value)
                 traceCollector.logger?.log("Operator header: \(name): \(value)", level: .debug)
             }
         }

--- a/Sources/VonageClientLibrary/CellularClient/TraceCollector.swift
+++ b/Sources/VonageClientLibrary/CellularClient/TraceCollector.swift
@@ -23,7 +23,7 @@ final class TraceCollector {
 
     /// Optional custom logger. When set, SDK log messages are forwarded here
     /// regardless of whether debug mode is enabled.
-    var logger: VGLogger?
+    weak var logger: VGLogger?
 
     /// Accumulates X-* operator headers seen across all hops (header name → array of values).
     private var _operatorHeaders: [String: [String]] = [:]

--- a/Sources/VonageClientLibrary/CellularClient/TraceCollector.swift
+++ b/Sources/VonageClientLibrary/CellularClient/TraceCollector.swift
@@ -21,15 +21,21 @@ final class TraceCollector {
     var isDebugInfoCollectionEnabled = false
     var isConsoleLogsEnabled = false
 
+    /// Optional custom logger. When set, SDK log messages are forwarded here
+    /// regardless of whether debug mode is enabled.
+    var logger: VGLogger?
+
+    /// Accumulates X-* operator headers seen across all hops (header name → array of values).
+    private var _operatorHeaders: [String: [String]] = [:]
+
     /// Stops trace and clears the internal buffer
     func startTrace() {
         queue.sync() {
             if !isTraceEnabled {
                 isTraceEnabled = true
-                //
                 trace.removeAll()
                 debugInfo.clear()
-                //
+                _operatorHeaders.removeAll()
                 trace.append("\(debugInfo.deviceString())\n")
                 debugInfo.add(log:"\(debugInfo.deviceString())\n")
             } else {
@@ -44,9 +50,9 @@ final class TraceCollector {
             isTraceEnabled = false
             isDebugInfoCollectionEnabled = false
             isConsoleLogsEnabled = false
-            //
             trace.removeAll()
             debugInfo.clear()
+            _operatorHeaders.removeAll()
         }
     }
 
@@ -75,6 +81,27 @@ final class TraceCollector {
         if self.isConsoleLogsEnabled {
             os_log("%s", type:type, log)
         }
+        let level: VGLogLevel
+        switch type {
+        case .error: level = .error
+        case .info: level = .info
+        default: level = .debug
+        }
+        logger?.log(log, level: level)
+    }
+
+    /// Accumulates an `X-*` operator header value. Thread-safe.
+    func addOperatorHeader(name: String, value: String) {
+        queue.sync {
+            var values = _operatorHeaders[name] ?? []
+            values.append(value)
+            _operatorHeaders[name] = values
+        }
+    }
+
+    /// Returns a snapshot of all accumulated operator headers. Thread-safe.
+    func operatorHeaders() -> [String: [String]] {
+        queue.sync { _operatorHeaders }
     }
     
     func addBody(body: [String : Any]?) {

--- a/Sources/VonageClientLibrary/VGCellularRequestClient.swift
+++ b/Sources/VonageClientLibrary/VGCellularRequestClient.swift
@@ -31,7 +31,7 @@ enum VGCellularRequestError: Error {
     var cellularClient: CellularClient
 
     /// Assign a custom logger to receive SDK log messages through your preferred logging framework.
-    @objc public var logger: VGLogger?
+    @objc public weak var logger: VGLogger?
     
     override public init() {
         self.cellularClient = VGCellularClient()

--- a/Sources/VonageClientLibrary/VGCellularRequestClient.swift
+++ b/Sources/VonageClientLibrary/VGCellularRequestClient.swift
@@ -29,6 +29,9 @@ enum VGCellularRequestError: Error {
 
 @objc public final class VGCellularRequestClient: NSObject {
     var cellularClient: CellularClient
+
+    /// Assign a custom logger to receive SDK log messages through your preferred logging framework.
+    @objc public var logger: VGLogger?
     
     override public init() {
         self.cellularClient = VGCellularClient()
@@ -43,10 +46,10 @@ enum VGCellularRequestError: Error {
     /// This method performs a GET request given a URL with cellular connectivity
     /// - Parameters:
     ///   - params: Parameters to configure your GET request
-    ///   - debug: A flag to include or not the url trace in the response, defaults to false
+    ///   - debug: A flag to include or not the url trace and operator headers in the response, defaults to false
     @objc public func startCellularGetRequest(params: VGCellularRequestParameters, debug: Bool = false) async throws -> [String: Any] {
         if let url = constructURL(params: params) {
-            let response = await cellularClient.get(url: url, headers: params.headers, maxRedirectCount: params.maxRedirectCount, debug: debug, timeout: params.timeout)
+            let response = await cellularClient.get(url: url, headers: params.headers, maxRedirectCount: params.maxRedirectCount, debug: debug, timeout: params.timeout, logger: logger)
             return response
         } else {
             throw VGCellularRequestError.invalidUrl

--- a/Sources/VonageClientLibrary/VGLogger.swift
+++ b/Sources/VonageClientLibrary/VGLogger.swift
@@ -1,0 +1,37 @@
+//
+//  VGLogger.swift
+//
+//
+//  Created by Vonage.
+//
+
+import Foundation
+
+/// Log severity levels used by the Vonage SDK.
+@objc public enum VGLogLevel: Int {
+    case debug = 0
+    case info = 1
+    case warning = 2
+    case error = 3
+}
+
+/// Conform to this protocol and set it on ``VGCellularRequestClient/logger`` to receive
+/// SDK log messages through your preferred logging framework.
+///
+/// Example:
+/// ```swift
+/// class MyLogger: NSObject, VGLogger {
+///     func log(_ message: String, level: VGLogLevel) {
+///         // forward to CocoaLumberjack, OSLog, etc.
+///     }
+/// }
+/// let client = VGCellularRequestClient()
+/// client.logger = MyLogger()
+/// ```
+@objc public protocol VGLogger: NSObjectProtocol {
+    /// Called by the SDK whenever it emits a log message.
+    /// - Parameters:
+    ///   - message: The log message.
+    ///   - level: The severity level of the message.
+    func log(_ message: String, level: VGLogLevel)
+}

--- a/Tests/VonageClientLibraryTests/MockCellularClient.swift
+++ b/Tests/VonageClientLibraryTests/MockCellularClient.swift
@@ -43,7 +43,7 @@ class MockCellularClientWithDebugResponse: CellularClient {
             var debugJson: [String: Any] = [:]
             debugJson["device_info"] = "iOS/17.0"
             debugJson["url_trace"] = ""
-            debugJson["operator_headers"] = ["X-Orange-Trace-Id": ["abc123"], "X-Custom-Op": ["val1", "val2"]]
+            debugJson["operator_headers"] = ["x-orange-trace-id": ["abc123"], "x-custom-op": ["val1", "val2"]]
             json["debug"] = debugJson
         }
         return json

--- a/Tests/VonageClientLibraryTests/MockCellularClient.swift
+++ b/Tests/VonageClientLibraryTests/MockCellularClient.swift
@@ -12,19 +12,49 @@ import Foundation
 class MockCellularClient: CellularClient {
     var urlString: String = ""
     
-    func get(url: URL, headers: [String : String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval) async -> [String : Any] {
+    func get(url: URL, headers: [String : String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?) async -> [String : Any] {
         self.urlString = url.absoluteString
         return [:]
     }
 }
 
 class MockCellularClientWithConnectivityError: CellularClient {
-    func get(url: URL, headers: [String : String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval) async -> [String : Any] {
+    func get(url: URL, headers: [String : String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?) async -> [String : Any] {
         // Simulate the sdk_no_data_connectivity error response
         // (mirrors the Android SDK's "Data connectivity not available" error)
         var json: [String: Any] = [:]
         json["error"] = "sdk_no_data_connectivity"
         json["error_description"] = "Data connectivity not available"
         return json
+    }
+}
+
+/// Mock that forwards to a real debug-enabled response including operator_headers
+class MockCellularClientWithDebugResponse: CellularClient {
+    /// The logger passed to the last `get` call, for inspection in tests.
+    var capturedLogger: VGLogger?
+
+    func get(url: URL, headers: [String : String], maxRedirectCount: Int, debug: Bool, timeout: TimeInterval, logger: VGLogger?) async -> [String : Any] {
+        capturedLogger = logger
+        logger?.log("Test SDK log message", level: .debug)
+        var json: [String: Any] = [:]
+        json["http_status"] = 200
+        if debug {
+            var debugJson: [String: Any] = [:]
+            debugJson["device_info"] = "iOS/17.0"
+            debugJson["url_trace"] = ""
+            debugJson["operator_headers"] = ["X-Orange-Trace-Id": ["abc123"], "X-Custom-Op": ["val1", "val2"]]
+            json["debug"] = debugJson
+        }
+        return json
+    }
+}
+
+/// A test logger that records received messages.
+class SpyLogger: NSObject, VGLogger {
+    var messages: [(message: String, level: VGLogLevel)] = []
+
+    func log(_ message: String, level: VGLogLevel) {
+        messages.append((message, level))
     }
 }

--- a/Tests/VonageClientLibraryTests/VonageClientSDKNumberVerificationTests.swift
+++ b/Tests/VonageClientLibraryTests/VonageClientSDKNumberVerificationTests.swift
@@ -55,7 +55,7 @@ final class VonageClientLibraryTests: XCTestCase {
 
         _ = try await client.startCellularGetRequest(params: params, debug: true)
 
-        XCTAssertTrue(spyLogger.messages.count > 0, "Logger should have received at least one message")
+        XCTAssertFalse(spyLogger.messages.isEmpty, "Logger should have received at least one message")
         XCTAssertNotNil(mockClient.capturedLogger, "Logger should have been passed to the cellular client")
     }
 
@@ -82,8 +82,8 @@ final class VonageClientLibraryTests: XCTestCase {
         XCTAssertNotNil(debug, "debug dict should be present when debug: true")
         let operatorHeaders = debug?["operator_headers"] as? [String: [String]]
         XCTAssertNotNil(operatorHeaders, "operator_headers should be present in debug dict")
-        XCTAssertEqual(operatorHeaders?["X-Orange-Trace-Id"], ["abc123"])
-        XCTAssertEqual(operatorHeaders?["X-Custom-Op"], ["val1", "val2"])
+        XCTAssertEqual(operatorHeaders?["x-orange-trace-id"], ["abc123"])
+        XCTAssertEqual(operatorHeaders?["x-custom-op"], ["val1", "val2"])
     }
 
     func testDebugResponse_operatorHeadersAbsentWhenDebugFalse() async throws {

--- a/Tests/VonageClientLibraryTests/VonageClientSDKNumberVerificationTests.swift
+++ b/Tests/VonageClientLibraryTests/VonageClientSDKNumberVerificationTests.swift
@@ -43,4 +43,56 @@ final class VonageClientLibraryTests: XCTestCase {
         XCTAssertEqual(result["error"] as? String, "sdk_no_data_connectivity")
         XCTAssertEqual(result["error_description"] as? String, "Data connectivity not available")
     }
+
+    // MARK: - Logger tests
+
+    func testCustomLogger_receivesMessages() async throws {
+        let params = VGCellularRequestParameters(url: "http://www.vonage.com", headers: [:], queryParameters: [:])
+        let spyLogger = SpyLogger()
+        let mockClient = MockCellularClientWithDebugResponse()
+        let client = VGCellularRequestClient(cellularClient: mockClient)
+        client.logger = spyLogger
+
+        _ = try await client.startCellularGetRequest(params: params, debug: true)
+
+        XCTAssertTrue(spyLogger.messages.count > 0, "Logger should have received at least one message")
+        XCTAssertNotNil(mockClient.capturedLogger, "Logger should have been passed to the cellular client")
+    }
+
+    func testCustomLogger_isPassedToClient() async throws {
+        let params = VGCellularRequestParameters(url: "http://www.vonage.com", headers: [:], queryParameters: [:])
+        let spyLogger = SpyLogger()
+        let mockClient = MockCellularClientWithDebugResponse()
+        let client = VGCellularRequestClient(cellularClient: mockClient)
+        client.logger = spyLogger
+
+        _ = try await client.startCellularGetRequest(params: params)
+
+        XCTAssertTrue(mockClient.capturedLogger === spyLogger, "The exact logger instance should be forwarded to the cellular client")
+    }
+
+    func testDebugResponse_containsOperatorHeaders() async throws {
+        let params = VGCellularRequestParameters(url: "http://www.vonage.com", headers: [:], queryParameters: [:])
+        let mockClient = MockCellularClientWithDebugResponse()
+        let client = VGCellularRequestClient(cellularClient: mockClient)
+
+        let result = try await client.startCellularGetRequest(params: params, debug: true)
+
+        let debug = result["debug"] as? [String: Any]
+        XCTAssertNotNil(debug, "debug dict should be present when debug: true")
+        let operatorHeaders = debug?["operator_headers"] as? [String: [String]]
+        XCTAssertNotNil(operatorHeaders, "operator_headers should be present in debug dict")
+        XCTAssertEqual(operatorHeaders?["X-Orange-Trace-Id"], ["abc123"])
+        XCTAssertEqual(operatorHeaders?["X-Custom-Op"], ["val1", "val2"])
+    }
+
+    func testDebugResponse_operatorHeadersAbsentWhenDebugFalse() async throws {
+        let params = VGCellularRequestParameters(url: "http://www.vonage.com", headers: [:], queryParameters: [:])
+        let mockClient = MockCellularClientWithDebugResponse()
+        let client = VGCellularRequestClient(cellularClient: mockClient)
+
+        let result = try await client.startCellularGetRequest(params: params, debug: false)
+
+        XCTAssertNil(result["debug"], "debug dict should not be present when debug: false")
+    }
 }


### PR DESCRIPTION
## Summary
Implements the cellular connectivity pre-check to reduce Silent Auth latency. If the device has no cellular data available, the SDK returns `sdk_no_data_connectivity` immediately rather than attempting the request and waiting for it to fail.

This PR adds enhanced debug logging for the redirect and response header flow, building on the core connectivity pre-check work.

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11042